### PR TITLE
Feature: Refine deployment configuration

### DIFF
--- a/docs/DetectionSolutionAccelerator/Model-Deployment-Cloud.md
+++ b/docs/DetectionSolutionAccelerator/Model-Deployment-Cloud.md
@@ -19,10 +19,18 @@ When deploying a model there are several parameters to be set. In order to make 
     "ENV_CONFIG_FILE": "dev_config.json",
     "EXPERIMENT" : "",
     "RUN_ID" : "",
-    "USE_ACI" : true,
+    "TF_VERSION": 2,
+    "REG_MODEL" : true,
     "IMAGE_TYPE": "",
-    "COMPUTE_TARGET_NAME" : "",
-    "REG_MODEL" : false
+    "ACI_PARAMS": {
+        "USE_ACI": true,
+        "ACI_AUTH": true
+    },
+    "AKS_PARAMS": {
+        "USE_AKS": false,
+        "VM_TYPE": "Standard_NC6",
+        "COMPUTE_TARGET_NAME" : ""
+    }
 }
 ```
 
@@ -34,13 +42,23 @@ Below a breakdown of each parameter can be obtained:
 
 - `RUN_ID` - This is the run ID from AML of the model you wish to deploy. This can be found from the Experiment view in AML
 
-- `USE_ACI` - Set this to true if you wish to deploy a model to ACI (this is for testing purposes only)
+- `TF_VERSION` - This is the tensorflow version (1 or 2), needed to specify different scoring script
+
+- `REG_MODEL` - If the model needs to be registered or not from the run_id. If set to false the deployment will check the model registry for a registered model with a runid tag matching that of your set RUN_ID
 
 - `IMAGE_TYPE` - The type of image or "use case" name as defined in the storage as the use case parent folder.
 
-- `COMPUTE_TARGET_NAME` - This will be the name of your deployed service and compute. If this already exists it will be updated
+- `ACI_PARAMS.USE_ACI` - Set this to true if you wish to deploy a model to ACI (this is for testing purposes only)
 
-- `REG_MODEL` - if the model needs to be registered or not from the run_id. If set to false the deployment will check the model registry for a registered model with a runid tag matching that of your set RUN_ID
+- `ACI_PARAMS.ACI_AUTH` - Whether to enable key-based authentication when using ACI, default value is true
+
+- `AKS_PARAMS.USE_AKS` - Set this to true if you wish to deploy a model to AKS, this is more suitable for production usage
+
+- `AKS_PARAMS.COMPUTE_TARGET_NAME` - This will be the name of your deployed service and compute. If this already exists it will be updated
+
+- `AKS_PARAMS.VM_TYPE` - Machine type of AKS cluster, default value is "Standard_NC6"
+
+
 
 ## Running Model Deployment
 

--- a/docs/DetectionSolutionAccelerator/Quickstart.md
+++ b/docs/DetectionSolutionAccelerator/Quickstart.md
@@ -213,7 +213,7 @@ The experiment config stores all the model training run paramters. It needs to b
 
 #### Deployment Config
 
-The deployment config stores the deployment paramters and points to the desired training run to deploy the model from. This config needs to be created under the deployment directory within src called deploy_config.json. An example config is provided already in this location called deploy_config_sample.json. A more detailed breakdown of each paramter can be found under model deployment cloud.
+The deployment config stores the deployment parameters and points to the desired training run to deploy the model from. This config needs to be created under the deployment directory within src called deploy_config.json. An example config is provided already in this location called deploy_config_sample.json. A more detailed breakdown of each paramter can be found under model deployment cloud.
 
 ```json
 {
@@ -221,10 +221,17 @@ The deployment config stores the deployment paramters and points to the desired 
     "EXPERIMENT" : "",
     "RUN_ID" : "",
     "TF_VERSION": 2,
-    "USE_ACI" : true,
+    "REG_MODEL" : true,
     "IMAGE_TYPE": "",
-    "COMPUTE_TARGET_NAME" : "",
-    "REG_MODEL" : false
+    "ACI_PARAMS": {
+        "USE_ACI": true,
+        "ACI_AUTH": true
+    },
+    "AKS_PARAMS": {
+        "USE_AKS": false,
+        "VM_TYPE": "Standard_NC6",
+        "COMPUTE_TARGET_NAME" : ""
+    }
 }
 ```
 

--- a/src/deployment/conda_env.yml
+++ b/src/deployment/conda_env.yml
@@ -5,12 +5,11 @@ dependencies:
 - pip:
   - azureml-core==1.27.0
   - azureml-defaults==1.27.0
-  - joblib
-  - azureml-sdk
-  - pillow
+  - joblib==1.1.0
+  - azureml-sdk==1.27.0
+  - pillow==9.0.1
   - tensorflow-gpu==1.15
-  - numpy
-  - joblib
-  - gunicorn
-  - flask
+  - numpy==1.21.5
+  - itsdangerous==2.0.1
+
 name: basic_env

--- a/src/deployment/conda_env_tf2.yml
+++ b/src/deployment/conda_env_tf2.yml
@@ -5,12 +5,11 @@ dependencies:
 - pip:
   - azureml-core==1.27.0
   - azureml-defaults==1.27.0
-  - joblib
-  - azureml-sdk
-  - pillow
-  - tensorflow
-  - numpy
-  - joblib
-  - gunicorn
-  - flask
+  - joblib==1.1.0
+  - azureml-sdk==1.27.0
+  - pillow==9.0.1
+  - tensorflow==2.8.0
+  - numpy==1.21.5
+  - itsdangerous==2.0.1
+
 name: basic_env

--- a/src/deployment/deploy_config_sample.json
+++ b/src/deployment/deploy_config_sample.json
@@ -3,8 +3,15 @@
     "EXPERIMENT" : "",
     "RUN_ID" : "",
     "TF_VERSION": 2,
-    "USE_ACI" : true,
+    "REG_MODEL" : true,
     "IMAGE_TYPE": "",
-    "COMPUTE_TARGET_NAME" : "",
-    "REG_MODEL" : false
+    "ACI_PARAMS": {
+        "USE_ACI": true,
+        "ACI_AUTH": true
+    },
+    "AKS_PARAMS": {
+        "USE_AKS": false,
+        "VM_TYPE": "Standard_NC6",
+        "COMPUTE_TARGET_NAME" : ""
+    }
 }

--- a/src/packages/azure_utils/azure_utils/deployment.py
+++ b/src/packages/azure_utils/azure_utils/deployment.py
@@ -48,9 +48,10 @@ class AMLDeploy(AML):
                    ssl_cert_pem=None,
                    ssl_key_pem=None,
                    ssl_cname=None,
-                   exists=True):
+                   exists=False):
         """
         Creates an AKS service based on the provided configuration
+        :param compute_name: AKS cluster name
         :param vm_type: Azure VM type to use, defaults to 'Standard_NC6' (str)
         :param nodes: Numebr of VM nodes for service, defaults to 3 (int)
         :param app_insights: Enable app insights, defaults to false (bool)
@@ -60,6 +61,7 @@ class AMLDeploy(AML):
         web service. The address that's stamped into the certificate and the
         address that the clients use are compared to verify the identity
         of the web service
+        :param exists: Existence of the given compute name, defaults to true (bool)
         """
 
         if exists:
@@ -98,6 +100,7 @@ class AMLDeploy(AML):
                    cpu_cores=2,
                    memory_gb=4,
                    app_insights=False,
+                   aci_auth=True,
                    ssl_cert_pem=None,
                    ssl_key_pem=None,
                    ssl_cname=None):
@@ -106,6 +109,7 @@ class AMLDeploy(AML):
         :param cpu_cores: number of cpu cores, defaults to 2 (int)
         :param memory_gb: memory allocation for instance, defaults to 4 (int)
         :param app_insights: Enable app insights, defaults to false (bool)
+        :param aci_auth: Enable key-based auth, defaults to true (bool)
         :param ssl_cert_pem: PEM-encoded certificate file
         :param ssl_key_pem: PEM-encoded key file
         :param ssl_cname: FQDN of the address that you plan to use for the
@@ -121,7 +125,8 @@ class AMLDeploy(AML):
             config = (AciWebservice
                       .deploy_configuration(cpu_cores=cpu_cores,
                                             memory_gb=memory_gb,
-                                            enable_app_insights=app_insights))
+                                            enable_app_insights=app_insights,
+                                            auth_enabled=aci_auth))
         else:
             print('ssl params provided')
             print('config will use HTTPS')
@@ -129,6 +134,7 @@ class AMLDeploy(AML):
                       .deploy_configuration(cpu_cores=cpu_cores,
                                             memory_gb=memory_gb,
                                             enable_app_insights=app_insights,
+                                            auth_enabled=aci_auth,
                                             ssl_enabled=True,
                                             ssl_cert_pem_file=ssl_cert_pem,
                                             ssl_key_pem_file=ssl_key_pem,


### PR DESCRIPTION
Hello 👋 ,

with the following 3 commits I would like to refine some features of model deployment:

- Package `version audit` of inferencing environment.
Currently some packages are not fixed and this might introduce conflict in case of package new release, see https://github.com/pallets/itsdangerous/issues/290
- Extend deployment configurations with options of using `key-based auth` when deployment on ACI (currently set default to false), and specifying `machine type` (currently only possible with `Standard_NC6`) when deployed on AKS.
- Update respective docs

Thank you,
Hong

